### PR TITLE
Add a new if-else branch to DLLexists support function

### DIFF
--- a/2 SupportFunctions/SupportFunctions.vb
+++ b/2 SupportFunctions/SupportFunctions.vb
@@ -41,6 +41,8 @@ Module SupportFunctions
             If Strings.InStr(pFilePath, "file:///") Then
                 Dim myNewFN As String = Strings.Right$(pFilePath, Len(pFilePath) - 8)
                 If System.IO.File.Exists(myNewFN) Then Return True
+            ElseIf Strings.InStr(pFilePath, ":\") Or Strings.InStr(pFilePath, ":/") Then
+                If System.IO.File.Exists(pFilePath) Then Return True
             End If
 
         Catch ex As Exception


### PR DESCRIPTION
Add a new check if the DLL path written in registry without 'file:///' prefix. In this case check is path exist ':/' or '\:' string (e.g. C:\ or D:/) and not necessary to cut out the first 8 char.

This case occur when install an EA Add-in via MSI packed by Visual Studio Deployment Project